### PR TITLE
Fix: DB 타임존, Store 컬럼 길이 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ db/
 
 ### VS Code ###
 .vscode/
+
+### ElasticSearch ###
+elasticsearch/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - MYSQL_DATABASE=${DATABASE_NAME}
       - MYSQL_USER=${DATABASE_USER}
       - MYSQL_PASSWORD=${DATABASE_PASSWORD}
+      - TZ=Asia/Seoul
 
   redis:
     image: redis:alpine

--- a/src/main/java/com/sangchu/batch/patch/entity/Store.java
+++ b/src/main/java/com/sangchu/batch/patch/entity/Store.java
@@ -120,13 +120,13 @@ public class Store {
 	@Column(length = 4, nullable = false)
 	private String newZipCd;
 
-	@Column(length = 5)
+	@Column(length = 50)
 	private String block;
 
-	@Column(length = 5)
+	@Column(length = 50)
 	private String floor;
 
-	@Column(length = 5)
+	@Column(length = 50)
 	private String room;
 
 	@Column(length = 15, nullable = false)


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - DB에 데이터 import과정 중 수정해야 할 사항 수정
 ## 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- MySQL 컨테이너의 Timezone을 Asia/Seoul로 수정
- Store에서 block,floor,room 컬럼의 길이 제한을 50으로 수정
- gitignore에서 elasticsearch의 데이터 경로를 추가
 ## Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #3333") -->
 - close #7 
