### PR TITLE
Refactor: Repository에서 가장 최근 분기의 가게만 불러오도록 Query문 수정

### DIFF
--- a/src/main/java/com/sangchu/preprocess/etl/repository/StoreRepository.java
+++ b/src/main/java/com/sangchu/preprocess/etl/repository/StoreRepository.java
@@ -19,8 +19,9 @@ public interface StoreRepository extends JpaRepository<Store, Integer> {
     SELECT * FROM store
     WHERE (branch_nm IS NULL OR branch_nm = :empty)
     AND id > :lastId
+    AND crtr_ym = (SELECT MAX(crtr_ym) FROM store)
     ORDER BY id ASC
     LIMIT :size
     """, nativeQuery = true)
-    List<Store> findStoresAfterId(@Param("empty") String empty, @Param("lastId") Integer lastId, @Param("size") int size);
+    List<Store> findRecentStoresAfterId(@Param("empty") String empty, @Param("lastId") Integer lastId, @Param("size") int size);
 }

--- a/src/main/java/com/sangchu/preprocess/etl/service/StoreHelperService.java
+++ b/src/main/java/com/sangchu/preprocess/etl/service/StoreHelperService.java
@@ -16,7 +16,7 @@ public class StoreHelperService {
     public List<Store> getStoreWithoutFranchise(Long lastId, int size) {
         // lastId가 null이면 0으로 초기화
         Long cursor = lastId != null ? lastId : 0;
-        return storeRepository.findStoresAfterId("", Math.toIntExact(cursor), size);
+        return storeRepository.findRecentStoresAfterId("", Math.toIntExact(cursor), size);
     }
 }
 


### PR DESCRIPTION
 ## 개요
  - 데이터의 용량이 너무 크고, 기존의 저장된 데이터들을 중복 저장하는 로직으로 구현되어 있어서 수정함.
 ## 작업사항
  - mysql의 모든 데이터를 불러 오지 않고 최근 분기의 데이터만 찾아서 elasticsearch로 넣도록 수정함.
 ## Issue 번호
 - close #23 
