### PR TITLE
Refactor: 사용자 검색어에 기반한 트렌드 키워드 추출 로직 변경

### DIFF
--- a/src/main/java/com/sangchu/elasticsearch/CosineSimilarity.java
+++ b/src/main/java/com/sangchu/elasticsearch/CosineSimilarity.java
@@ -3,8 +3,8 @@ package com.sangchu.elasticsearch;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.StreamSupport;
 
+import com.sangchu.elasticsearch.service.RecentIndexingService;
 import com.sangchu.embedding.service.EmbeddingService;
 import com.sangchu.global.exception.custom.CustomException;
 import com.sangchu.global.util.statuscode.ApiStatus;
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CosineSimilarity {
 	private final EmbeddingService embeddingService;
-	private final StoreSearchDocRepository elasticRepository;
+	private final RecentIndexingService recentIndexingService;
 
 	public static double cosineSimilarity(Embedding vec1, float[] vec2) {
 		float[] a = vec1.getOutput();
@@ -47,9 +47,7 @@ public class CosineSimilarity {
 	public Map<String, Integer> getWordFrequency(String keyword) {
 		Embedding keywordEmbedding = embeddingService.getEmbedding(keyword);
 
-		Iterable<StoreSearchDoc> iterable = elasticRepository.findAll();
-		List<StoreSearchDoc> allDocs = StreamSupport.stream(iterable.spliterator(), false).toList();
-
+		List<StoreSearchDoc> allDocs = recentIndexingService.findRecentCrtrYmDocs();
 		// 1. 유사도 필터링 (0.5 이상)
 		List<StoreSearchDoc> similarDocs = allDocs.stream()
 			.filter(doc -> cosineSimilarity(keywordEmbedding, doc.getVector()) >= 0.5)

--- a/src/main/java/com/sangchu/elasticsearch/repository/RecentIndexingDocRepository.java
+++ b/src/main/java/com/sangchu/elasticsearch/repository/RecentIndexingDocRepository.java
@@ -3,6 +3,8 @@ package com.sangchu.elasticsearch.repository;
 import com.sangchu.elasticsearch.entity.RecentIndexingDoc;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
-public interface RecentIndexingDocRepository extends ElasticsearchRepository<RecentIndexingDoc, String> {
+import java.util.Optional;
 
+public interface RecentIndexingDocRepository extends ElasticsearchRepository<RecentIndexingDoc, String> {
+    Optional<RecentIndexingDoc> findById(String id);
 }

--- a/src/main/java/com/sangchu/elasticsearch/service/RecentIndexingService.java
+++ b/src/main/java/com/sangchu/elasticsearch/service/RecentIndexingService.java
@@ -1,18 +1,30 @@
 package com.sangchu.elasticsearch.service;
 
 import com.sangchu.elasticsearch.entity.RecentIndexingDoc;
+import com.sangchu.elasticsearch.entity.StoreSearchDoc;
 import com.sangchu.elasticsearch.repository.RecentIndexingDocRepository;
 import com.sangchu.global.exception.custom.CustomException;
 import com.sangchu.global.util.statuscode.ApiStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.stereotype.Service;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+
+import java.util.List;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class RecentIndexingService {
     private final RecentIndexingDocRepository recentIndexingDocRepository;
+    private final ElasticsearchOperations elasticsearchOperations;
+
 
     public void indexRecentCrtrYm(String crtrYm) {
         try {
@@ -26,4 +38,25 @@ public class RecentIndexingService {
             throw new CustomException(ApiStatus._ES_CRTRYM_INDEXING_FAIL , "최근 분기 인덱싱 중 예외 발생 - crtrYm : " + crtrYm);
         }
     }
+
+    public List<StoreSearchDoc> findRecentCrtrYmDocs() {
+        // 1. 최근 분기 crtrYm 가져오기 (ID가 1인 단일 문서)
+        String crtrYm = recentIndexingDocRepository.findById("1")
+                .orElseThrow(() -> new CustomException(ApiStatus._RECENT_CRTRYM_NOT_FOUND))
+                .getCrtrYm();
+
+        // 2. 동적 인덱스 지정
+        String indexName = "store_search_doc-" + crtrYm;
+
+        Query query = new CriteriaQuery(new Criteria());
+
+        SearchHits<StoreSearchDoc> searchHits = elasticsearchOperations.search(
+                query,
+                StoreSearchDoc.class,
+                IndexCoordinates.of(indexName)
+        );
+
+        return searchHits.get().map(SearchHit::getContent).toList();
+    }
+
 }

--- a/src/main/java/com/sangchu/global/util/statuscode/ApiStatus.java
+++ b/src/main/java/com/sangchu/global/util/statuscode/ApiStatus.java
@@ -35,7 +35,8 @@ public enum ApiStatus {
 	_READ_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 500, "DB 읽기에 실패하였습니다."),
 	_ES_CRTRYM_INDEXING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 500, "최근 분기 INDEXING 작업에 실패하였습니다."),
 	_ES_BULK_INDEXING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 500, "Index 생성 중 에러 발생"),
-	_ES_INDEX_QUERY_CREATE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 500, "IndexQuery 생성 중 에러 발생");
+	_ES_INDEX_QUERY_CREATE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 500, "IndexQuery 생성 중 에러 발생"),
+	_RECENT_CRTRYM_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR,500 ,"최근 분기 정보가 없습니다.");
 
 
 	private final HttpStatus httpStatus;


### PR DESCRIPTION
 ## 개요
  - 워드 클라우드에 사용할 트렌드 키워드는 최신 데이터에 기반해서 추출해야 함.
 ## 작업사항
  - elasticsearch의 store_search_doc-*에서 가져오는 것이 아닌 최근 crtrYm을 찾아서 인덱스 이름이 store_search_doc_${crtrYm}인 인덱스에서 트렌드 키워드 추출
 ## Issue 번호
 - close #25 
