### PR TITLE
Fix: 중복 검사 시, 기존 API보다 좀 더 정확한 API로 변경

### DIFF
--- a/src/main/java/com/sangchu/patent/controller/PatentController.java
+++ b/src/main/java/com/sangchu/patent/controller/PatentController.java
@@ -12,11 +12,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.xml.sax.SAXException;
-
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.IOException;
-import java.net.URISyntaxException;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,7 +25,7 @@ public class PatentController {
             @RequestParam("keyword") String keyword,
             @RequestParam("custom") String custom,
             @RequestParam("storeNm") String storeNm
-    ) throws URISyntaxException, IOException, ParserConfigurationException, SAXException {
+    ) {
         PreferNameCreateDto preferName = PreferNameCreateDto.builder().keyword(keyword).custom(custom).name(storeNm).build();
         preferService.createPreferName(preferName);
         Boolean response = patentService.checkDuplicated(storeNm);

--- a/src/main/java/com/sangchu/patent/service/PatentService.java
+++ b/src/main/java/com/sangchu/patent/service/PatentService.java
@@ -2,24 +2,24 @@ package com.sangchu.patent.service;
 
 import com.sangchu.global.exception.custom.CustomException;
 import com.sangchu.global.util.statuscode.ApiStatus;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
+
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
@@ -27,34 +27,44 @@ import java.nio.charset.StandardCharsets;
 @RequiredArgsConstructor
 @Slf4j
 public class PatentService {
-    @Value("${kipris.service-key}")
-    private String serviceKey;
+	@Value("${kipris.service-key}")
+	private String serviceKey;
 
-    @Value("${kipris.request-url}")
-    private String requestUrl;
+	@Value("${kipris.request-url}")
+	private String requestUrl;
 
-    private final RestTemplate restTemplate = new RestTemplate();
+	private final RestTemplate restTemplate = new RestTemplate();
 
-    public Boolean checkDuplicated(String storeNm) throws URISyntaxException, IOException, ParserConfigurationException, SAXException {
-        try {
-            String url = requestUrl + "?word=" + URLEncoder.encode(storeNm, StandardCharsets.UTF_8) + "&ServiceKey=" + serviceKey;
-            ResponseEntity<String> response = restTemplate.getForEntity(new URI(url), String.class);
+	public Boolean checkDuplicated(String storeNm) {
+		try {
+			String url =
+				requestUrl + "?trademarkName=" + URLEncoder.encode(storeNm, StandardCharsets.UTF_8) + "&accessKey="
+					+ serviceKey;
+			ResponseEntity<String> response = restTemplate.getForEntity(new URI(url), String.class);
 
-            if (response.getStatusCode() != HttpStatus.OK) return false;
+			if (response.getStatusCode() != HttpStatus.OK)
+				return false;
 
-            String xml = response.getBody();
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder builder = factory.newDocumentBuilder();
+			String xml = response.getBody();
 
-            Document document = builder.parse(new ByteArrayInputStream(xml.getBytes("UTF-8")));
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			DocumentBuilder builder = factory.newDocumentBuilder();
 
-            String totalCount = document.getElementsByTagName("totalCount").item(0).getTextContent();
+			Document document = builder.parse(new ByteArrayInputStream(xml.getBytes("UTF-8")));
 
-            log.info("totalCount: " + totalCount);
-
-            return Integer.parseInt(totalCount) > 0;
-        } catch (Exception e) {
-            throw new CustomException(ApiStatus._PATENT_CHECK_FAIL);
-        }
-    }
+			String totalCountText = document.getElementsByTagName("TotalSearchCount").item(0).getTextContent();
+			NodeList applicationStatusNodeList = document.getElementsByTagName("ApplicationStatus");
+			boolean patentCheck = false;
+			for (int i = 0; i < applicationStatusNodeList.getLength(); i++) {
+				String applicationStatus = applicationStatusNodeList.item(i).getTextContent();
+				if ("등록".equals(applicationStatus) || "출원".equals(applicationStatus)) {
+					patentCheck = true;
+					break;
+				}
+			}
+			return patentCheck || Integer.parseInt(totalCountText) > 0;
+		} catch (Exception e) {
+			throw new CustomException(ApiStatus._PATENT_CHECK_FAIL);
+		}
+	}
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 중복 검사 시, 기존 API보다 좀 더 정확한 API로 변경
 ## 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - env 파일에서 Kplus API 수정 : http://plus.kipris.or.kr/openapi/rest/trademarkInfoSearchService/trademarkNameSearchInfo
  - Response에 맞춰 totalCount -> TotalSearchCount로 수정
  - 중복 체크 조건에서 상표가 등록 or 출원 상태도 확인하는 로직 추가
  - patentCheck로 상태 확인 후, 해당 조건이거나 count가 있을 시 등록 실패로 반환
  - throw exception에서 custom으로 다 던져서 기존의 exception 제거

 ## Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #3333") -->
 - close #54 
